### PR TITLE
update artemis manifest README files

### DIFF
--- a/manifests/artemis/01-single-instance/README.md
+++ b/manifests/artemis/01-single-instance/README.md
@@ -11,7 +11,12 @@ NOTE:
 
 If you are running in the local cluster using KinD deployed using the `create-kind` and `deploy-ingress-controller` you need to update the ingress to expose the acceptor ports of the instance to the host to be allowed to access it from the host. You may do it using the command below  from the project root directory, i.e: this command will expose the container 61610 port to the host 51510.:
 ```sh
-bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-all-0-svc --dst-port 61610
+bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-single-all-0-svc --dst-port 61610
+```
+
+To verify the artemis connection you can execute the command below (you will need artemis binary installed)
+```sh
+artemis queue stat --url tcp://localhost:51510
 ```
 
 Another example is to expose java remote debug port 5005, ie:

--- a/manifests/artemis/02-async-mirror/README.md
+++ b/manifests/artemis/02-async-mirror/README.md
@@ -13,7 +13,12 @@ NOTE:
 
 If you are running in the local cluster using KinD deployed using the `create-kind` and `deploy-ingress-controller` you need to update the ingress to expose the acceptor ports of the instance to the host to be allowed to access it from the host. You may do it using the command below  from the project root directory, i.e: This command will expose the container 61610 port to the host 51510.:
 ```sh
-bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-all-0-svc --dst-port 61610
+bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-single-all-0-svc --dst-port 61610
+```
+
+To verify the artemis connection you can execute the command below (you will need artemis binary installed)
+```sh
+artemis queue stat --url tcp://localhost:51510
 ```
 
 Another example is to expose java remote debug port 5005, ie:

--- a/manifests/artemis/03-jdbc-shared-store/README.md
+++ b/manifests/artemis/03-jdbc-shared-store/README.md
@@ -19,7 +19,12 @@ NOTE:
 
 If you are running in the local cluster using KinD deployed using the `create-kind` and `deploy-ingress-controller` you need to update the ingress to expose the acceptor ports of the instance to the host to be allowed to access it from the host. You may do it using the command below  from the project root directory, i.e: This command will expose the container 61610 port to the host 51510.:
 ```sh
-bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-all-0-svc --dst-port 61610
+bin/ingress-ngnix-expose-tcp-port.sh --src-port 51510 --namespace artemis-single-instance --dst-service artemis-single-all-0-svc --dst-port 61610
+```
+
+To verify the artemis connection you can execute the command below (you will need artemis binary installed)
+```sh
+artemis queue stat --url tcp://localhost:51510
 ```
 
 Another example is to expose java remote debug port 5005, ie:


### PR DESCRIPTION
Update artemis manifests README files to include an example of  how to connect to the artemis instance running in the cluster using the ingress mapped port